### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can install the dev version of **{kaggler}** from
 
 ``` r
 ## install kaggler package from github
-devtools::install_packages("mkearney/kaggler")
+devtools::install_github("mkearney/kaggler")
 ```
 
 ## API authorization


### PR DESCRIPTION
Changed command to install package with ```devtools``` from devtools:install_package to devtools:install_github. * API devtools:install_package does not exist but with github works fine. 